### PR TITLE
Feature: Fix a target directory's namespace usage based on the map file

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -50,6 +50,15 @@ return array(
                         ),
                     ),
                 ),
+                'namespacer-fix' => array(
+                    'options' => array(
+                        'route'    => 'fix [--mapfile=] [--target=]',
+                        'defaults' => array(
+                            'controller' => 'Namespacer\Controller\Controller',
+                            'action'     => 'fix',
+                        ),
+                    ),
+                ),
             ),
         ),
     ),

--- a/src/Namespacer/Controller/Controller.php
+++ b/src/Namespacer/Controller/Controller.php
@@ -5,6 +5,7 @@ namespace Namespacer\Controller;
 use Namespacer\Model\Map;
 use Namespacer\Model\Mapper;
 use Namespacer\Model\Transformer;
+use Namespacer\Model\Fixer;
 use Zend\Mvc\Controller\AbstractActionController;
 
 class Controller extends AbstractActionController
@@ -49,6 +50,17 @@ class Controller extends AbstractActionController
                 break;
         }
 
+    }
 
+    public function fixAction()
+    {
+        $mapfile = $this->params()->fromRoute('mapfile');
+        $source = $this->params()->fromRoute('target');
+        $data = include $mapfile;
+
+        $map   = new Map($data);
+        $fixer = new Fixer($map);
+
+        $fixer->fix($source);
     }
 }

--- a/src/Namespacer/Model/Fixer.php
+++ b/src/Namespacer/Model/Fixer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Namespacer\Model;
+
+class Fixer {
+
+	/** @var \Namespacer\Model\Map */
+    protected $map;
+
+    public function __construct(Map $map)
+    {
+        $this->map = $map;
+    }
+
+	public function fix($directory)
+	{
+		$rdi = new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS);
+        foreach (new \RecursiveIteratorIterator($rdi) as $file) {
+            /** @var $file \SplFileInfo */
+            if ($file->getExtension() != 'php') {
+                continue;
+            }
+
+            $this->fixNamespacesFromMap($file->getRealPath());
+        }
+	}	
+
+	protected function fixNamespacesFromMap($realPath)
+	{
+		$transformations = $this->map->getClassTransformations();
+		if (!file_exists($realPath)) {
+			throw new Exception('File not found');
+		}
+
+		$src = file_get_contents($realPath);
+		foreach ($transformations as $old => $new) {
+			$src = str_replace($old, $new, $src);
+		}	
+
+		file_put_contents($realPath, $src);
+	}
+}

--- a/src/Namespacer/Module.php
+++ b/src/Namespacer/Module.php
@@ -50,6 +50,7 @@ class Module implements ConsoleUsageProviderInterface, AutoloaderProviderInterfa
             'Basic information:',
             'map --mapfile <file> --source <sourcedir>' => 'create a map in file <file> from <source>',
             'transform --mapfile <file>' => 'transform the files in the map',
+            'fix --mapfile <file> --target <targetdir>' => 'fix namespace references in <target> according to the map in <file>',
         );
     }
 }


### PR DESCRIPTION
When converting a repo from ZF1 to ZF2 per the manual it's advised to not change change the Controller initially only the model classes. The problem is how do you change the references in your Controller classes so that they adhere to the transformation done with the namespacer tool.

Proposed solution:

Add new command called `fix` that takes as input map file and target directory. The command will use the map file to replace all references of the old namespace format with the new one.
